### PR TITLE
create and resuse single audioContext

### DIFF
--- a/audiobuffer-slice.js
+++ b/audiobuffer-slice.js
@@ -1,7 +1,7 @@
 (function(root) {
   'use strict';
 
-  window.AudioContext = window.AudioContext || window.webkitAudioContext;
+  var audioContext = new window.AudioContext || window.webkitAudioContext;
 
   function AudioBufferSlice(buffer, begin, end, callback) {
     if (!(this instanceof AudioBufferSlice)) {
@@ -41,8 +41,6 @@
     var newArrayBuffer;
 
     try {
-      var audioContext = new AudioContext();
-
       newArrayBuffer = audioContext.createBuffer(channels, endOffset, rate);
       var anotherArray = new Float32Array(frameCount);
       var offset = 0;


### PR DESCRIPTION
Issues can arise from some browser environments, like mobile browsers or Chrome on Mac OS X, where a limited number of AudioContexts can be created. Since the slice function creates a new one each time, this results in failure.

I am not sure if you want the npm version bumped as part of the pull request. Let me know if you do, I'll take care of it =)
