### PR TITLE
correct newArrayBuffer length

### DIFF
--- a/audiobuffer-slice.js
+++ b/audiobuffer-slice.js
@@ -41,7 +41,7 @@
     var newArrayBuffer;
 
     try {
-      newArrayBuffer = audioContext.createBuffer(channels, endOffset, rate);
+      newArrayBuffer = audioContext.createBuffer(channels, endOffset - startOffset, rate);
       var anotherArray = new Float32Array(frameCount);
       var offset = 0;
 


### PR DESCRIPTION
The previous array buffer length was being set as the `endOffset`. This didn't cause an operational failure, but it showed the newly sliced ArrayBuffer as having a duration of 0-to-endOffSet, instead of the correct beginOffSet-to-endOffset.
